### PR TITLE
 removed user email from post details page  #47

### DIFF
--- a/backend/src/routes/post/controller.ts
+++ b/backend/src/routes/post/controller.ts
@@ -124,7 +124,6 @@ export const getPostController = async (req: Request, res: Response) => {
           select: {
             id: true,
             username: true,
-            email: true,
           },
         },
       },
@@ -167,7 +166,6 @@ export const getPostsWithPagination = async (req: Request, res: Response) => {
           select: {
             id: true,
             username: true,
-            email: true,
           },
         },
       },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1404,6 +1404,12 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true
+    },
     "node_modules/@types/zxcvbn": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@types/zxcvbn/-/zxcvbn-4.4.4.tgz",

--- a/frontend/src/pages/Post.tsx
+++ b/frontend/src/pages/Post.tsx
@@ -90,6 +90,11 @@ const Post = () => {
     <div className="p-6 text-white max-w-screen-xl mx-auto">
       {post && (
         <>
+        <button onClick={() => window.history.back()} className="mb-4 px-2 py-1 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg> 
+          </button> 
           <h2 className="text-2xl font-semibold mb-4">{post.title}</h2>
           <p className="mb-4">{post.description}</p>
           <div className="relative mb-4">
@@ -157,7 +162,6 @@ const Post = () => {
           <div className="mb-4">
             <h3 className="text-xl font-semibold mb-2">Author</h3>
             <p>Username: {post.author.username}</p>
-            <p>Email: {post.author.email}</p>
           </div>
         </>
       )}


### PR DESCRIPTION
# Pull Request for Issue  #47

### Title
Removed the user email from the post details page and added a back button on it for better navigation

### Description
For security reasons, the email displayed at the bottom of the post details page is removed.

### Related Issues
N/A

### Changes Made
Mentioned above

### Checklist 

- [X] I have tested the changes locally
- [X] Documentation has been updated (if necessary)
- [X] Changes are backward-compatible

### Screenshots (if applicable)
N/A

### Additional Notes
N/A

Footer
