### PR TITLE
Corrected Toast  Fictionality

### DIFF
--- a/frontend/src/pages/Signin.tsx
+++ b/frontend/src/pages/Signin.tsx
@@ -40,16 +40,12 @@ const Signin = () => {
           message: string;
         };
       }>;
-      if (axiosError?.response?.data?.error) {
-        const errorMessage = axiosError.response.data.error.message;
-        toast.error(errorMessage);
-        setError({
-          ...error,
-          message: errorMessage,
-        });
-      } else {
-        toast.error("An unexpected error occurred");
-      }
+      const errorMessage = axiosError?.response?.data?.error?.message || "Invalid credentials. Please try again.";
+      toast.error(errorMessage);
+      setError({
+        ...error,
+        message: errorMessage,
+      });
     }
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "StyleShare",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "StyleShare",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Improved error handling for login failures by adding a default error message to ensure toast notifications and state updates always display a meaningful message.

# Pull Request

### Title
Improved Error Handling for Login Failures 

### Description
 Enhanced error handling to ensure meaningful error messages are always displayed during login failures. A default error message is now shown if the backend does not provide one.

### Related Issues
Fixes #158 

### Changes Made

1. Added a default error message for login failures.
2. Ensured toast notifications always display a meaningful message.
3. Updated state to accurately reflect the error message. 

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [x] Documentation has been updated (if necessary)


### Screenshots (if applicable)
![Screenshot (408)](https://github.com/VaibhavArora314/StyleShare/assets/119524954/6e9d7f0c-5890-4c53-847b-af27101d5dc7)




Footer
