### PR TITLE
fixed sizing for mobile screen

### DIFF
--- a/frontend/src/components/HeroText.tsx
+++ b/frontend/src/components/HeroText.tsx
@@ -7,20 +7,20 @@ export function TypewriterEffectSmoothDemo() {
   const words = [
     {
       text: t("hero.h1"),
-      className: "md:text-3xl lg:text-5xl text-3xl text-white"
+      className: "md:text-3xl lg:text-5xl text-xl text-white",
     },
     {
       text: t("hero.h2"),
-      className: "text-white lg:text-5xl md:text-3xl text-3xl"
+      className: "text-white lg:text-5xl md:text-3xl text-xl",
     },
     {
       text: t("hero.h3"),
-      className: "text-blue-500 lg:text-5xl md:text-3xl text-3xl"
+      className: "text-blue-500 lg:text-5xl md:text-3xl text-xl",
     },
     {
       text: t("hero.h4"),
-      className: "text-blue-500 lg:text-5xl md:text-3xl text-3xl"
-    }
+      className: "text-blue-500 lg:text-5xl md:text-3xl text-xl",
+    },
   ];
 
   return (

--- a/frontend/src/components/HeroText.tsx
+++ b/frontend/src/components/HeroText.tsx
@@ -7,19 +7,19 @@ export function TypewriterEffectSmoothDemo() {
   const words = [
     {
       text: t("hero.h1"),
-      className: "md:text-3xl lg:text-5xl text-xl text-white",
+      className: "md:text-3xl lg:text-5xl text-white text-typing ",
     },
     {
       text: t("hero.h2"),
-      className: "text-white lg:text-5xl md:text-3xl text-xl",
+      className: "text-white lg:text-5xl md:text-3xl text-typing",
     },
     {
       text: t("hero.h3"),
-      className: "text-blue-500 lg:text-5xl md:text-3xl text-xl",
+      className: "text-blue-500 lg:text-5xl md:text-3xl  text-typing ",
     },
     {
       text: t("hero.h4"),
-      className: "text-blue-500 lg:text-5xl md:text-3xl text-xl",
+      className: "text-blue-500 lg:text-5xl md:text-3xl text-typing",
     },
   ];
 

--- a/frontend/src/components/ui/TypeWriter.tsx
+++ b/frontend/src/components/ui/TypeWriter.tsx
@@ -140,7 +140,7 @@ export const TypewriterEffectSmooth = ({
   };
 
   return (
-    <div className={cn("flex space-x-1 my-6", className)}>
+    <div className={cn("flex space-x-1 my-6 items-center", className)}>
       <motion.div
         className="overflow-hidden pb-2"
         initial={{
@@ -156,7 +156,7 @@ export const TypewriterEffectSmooth = ({
         }}
       >
         <div
-          className="text-xs sm:text-base md:text-xl lg:text:3xl xl:text-5xl font-bold"
+          className=" sm:text-base md:text-xl lg:text:3xl xl:text-5xl font-bold"
           style={{
             whiteSpace: "nowrap",
           }}

--- a/frontend/src/styles/hero.css
+++ b/frontend/src/styles/hero.css
@@ -13,3 +13,24 @@
     transform: translatey(0px);
   }
 }
+.text-typing {
+  font-size: medium; /* Default font size */
+}
+
+@media (max-width: 320px) {
+  .text-typing {
+    font-size: large; /* Font size for screens up to 320px */
+  }
+}
+
+@media (min-width: 321px) and (max-width: 425px) {
+  .text-typing {
+    font-size: x-large; /* Font size for screens between 321px and 425px */
+  }
+}
+
+@media (min-width: 426px) and (max-width: 768px) {
+  .text-typing {
+    font-size: xx-large; /* Font size for screens between 426px and 768px */
+  }
+}


### PR DESCRIPTION
# Pull Request

### Title
Fixed hero sizing for mobile screen 
<!-- Provide a clear and concise title for the pull request -->

### Description
Fixed to have a proper sizing on mobile screen and the typing effect.
<!-- Brief summary of the changes made and the purpose of the PR -->

### Related Issues
Fixes #190 
<!-- Mention any related issue numbers (e.g., "Fixes #123") -->

### Changes Made
changed the sizing of text in typing effect to keep inside the screen for small screen size.
<!-- List of changes made in the PR (e.g., new features, bug fixes, improvements) -->

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [x] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Screenshots (if applicable)
<!-- Add any relevant screenshots to illustrate the changes -->
![image](https://github.com/VaibhavArora314/StyleShare/assets/124615886/e6b30928-7383-4ef0-ab7c-7abdab2915ee)


### Additional Notes
<!-- Any additional information that might be helpful for the reviewer -->

Footer
