### PR TITLE
Hover added on cards to y direction up side

### DIFF
--- a/frontend/src/components/Features.tsx
+++ b/frontend/src/components/Features.tsx
@@ -16,7 +16,7 @@ const Features = () => {
           </div>
           <div className="flex flex-wrap -m-4">
           <div className="xl:w-1/4 md:w-1/2 p-4">
-              <div className="border border-sky-500 border-opacity-75 p-6 rounded-lg hover:bg-blue-300 dark:hover:bg-blue-950 hover:border-sky-700 backdrop-blur-sm cursor-pointer">
+              <div className="border border-sky-500 border-opacity-75 p-6 rounded-lg hover:bg-blue-300 dark:hover:bg-blue-950 hover:border-sky-700 backdrop-blur-sm cursor-pointer transition-transform duration-300 hover:-translate-y-1">
                 <div className="w-10 h-10 inline-flex items-center justify-center rounded-full bg-sky-500 text-white mb-4">
                 <RiTailwindCssFill size={23}/>
                 </div>
@@ -25,7 +25,7 @@ const Features = () => {
               </div>
             </div>
             <div className="xl:w-1/4 md:w-1/2 p-4">
-              <div className="border border-sky-500 border-opacity-75 p-6 rounded-lg hover:bg-blue-300 dark:hover:bg-blue-950 hover:border-sky-700 backdrop-blur-sm cursor-pointer">
+              <div className="border border-sky-500 border-opacity-75 p-6 rounded-lg hover:bg-blue-300 dark:hover:bg-blue-950 hover:border-sky-700 backdrop-blur-sm cursor-pointer transition-transform duration-300 hover:-translate-y-1">
               <div className="w-10 h-10 inline-flex items-center justify-center rounded-full bg-sky-500 text-white mb-4">
                 <MdLeaderboard size={23}/>
                 </div>
@@ -34,7 +34,7 @@ const Features = () => {
               </div>
             </div>
             <div className="xl:w-1/4 md:w-1/2 p-4">
-              <div className="border border-sky-500 border-opacity-75 p-6 rounded-lg hover:bg-blue-300 dark:hover:bg-blue-950 hover:border-sky-700 backdrop-blur-sm cursor-pointer">
+              <div className="border border-sky-500 border-opacity-75 p-6 rounded-lg hover:bg-blue-300 dark:hover:bg-blue-950 hover:border-sky-700 backdrop-blur-sm cursor-pointer transition-transform duration-300 hover:-translate-y-1">
               <div className="w-10 h-10 inline-flex items-center justify-center rounded-full bg-sky-500 text-white mb-4">
                 <FaLaptopFile size={23}/>
                 </div>
@@ -43,7 +43,7 @@ const Features = () => {
               </div>
             </div>
             <div className="xl:w-1/4 md:w-1/2 p-4">
-              <div className="border border-sky-500 border-opacity-75 p-6 rounded-lg hover:bg-blue-300 dark:hover:bg-blue-950 hover:border-sky-700 backdrop-blur-sm cursor-pointer">
+              <div className="border border-sky-500 border-opacity-75 p-6 rounded-lg hover:bg-blue-300 dark:hover:bg-blue-950 hover:border-sky-700 backdrop-blur-sm cursor-pointer transition-transform duration-300 hover:-translate-y-1">
               <div className="w-10 h-10 inline-flex items-center justify-center rounded-full bg-sky-500 text-white mb-4">
                 <BiSolidCustomize size={23}/>
                 </div>


### PR DESCRIPTION
# Pull Request

### Title
Hover on y direction up side added.

### Description
Just added tailwind css to that 4 cards.

### Related Issues
<!-- Mention any related issue numbers (e.g., "Fixes #123") -->

### Changes Made
Added tailwind effects for y direction hover.

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [x] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Screenshots (if applicable)

https://www.loom.com/share/23d5fbd90fac43e6b786a1b65052e063

