### PR TITLE
Fix Next/Previous button distance for all size screen

### DIFF
--- a/frontend/src/components/TestimonialSlider.tsx
+++ b/frontend/src/components/TestimonialSlider.tsx
@@ -19,7 +19,7 @@ const TestimonialSlider: React.FC = () => {
   const testimonialsData = t('testimonials', { returnObjects: true }) as TestimonialsData;
 
   const [currentIndex, setCurrentIndex] = useState<number>(0);
-  const [slidesToShow, setSlidesToShow] = useState<number>(3);
+  const [slidesToShow, setSlidesToShow] = useState<number>(1);
   const [isHovered, setIsHovered] = useState<boolean>(false);
 
   useEffect(() => {
@@ -77,7 +77,7 @@ const TestimonialSlider: React.FC = () => {
       <h2 className="text-3xl md:text-4xl font-extrabold mb-8">{testimonialsData.title}</h2>
       <div className="testimonial-slider flex items-center justify-center w-full my-auto mx-auto">
         <button
-          className="prev-arrow text-4xl cursor-pointer transform hover:scale-125 transition-transform duration-300 mx-4"
+          className="prev-arrow text-4xl cursor-pointer transform hover:scale-110 transition-transform duration-300 mx-2 md:mx-4 lg:mx-6"
           onClick={goToPrevious}
         >
           &#9664;
@@ -96,7 +96,7 @@ const TestimonialSlider: React.FC = () => {
           ))}
         </div>
         <button
-          className="next-arrow text-4xl cursor-pointer transform hover:scale-125 transition-transform duration-300 mx-4"
+          className="next-arrow text-4xl cursor-pointer transform hover:scale-125 transition-transform duration-300 mx-2 md:mx-4 lg:mx-6"
           onClick={goToNext}
         >
           &#9654;


### PR DESCRIPTION
# Pull Request

### Title
Buttons very close to screen give it proper margins

### Description

Add proper margins for every screen like lg ,md and sm.

### Related Issues

Fixes #332

### Changes Made
 
Just added tailwind css for margins

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [x] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Screenshots (if applicable)
![image](https://github.com/VaibhavArora314/StyleShare/assets/126322584/12e4ee80-7fe1-464f-8919-5736c6adc55d)

![image](https://github.com/VaibhavArora314/StyleShare/assets/126322584/b9bb8bca-b9ef-4e69-81b4-21b07ee0a808)

![image](https://github.com/VaibhavArora314/StyleShare/assets/126322584/dc3bbd9d-d4d8-4f8e-9c3b-5f4e32a90d90)



