### PR TITLE
Fix hover radius and added Githubicon from react-icons

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,10 +1,9 @@
 import { useRecoilValue } from 'recoil';
-import github from '../assets/github.png';
 import { Link } from "react-router-dom";
 import { loggedInState } from '../store/atoms/auth';
 import { CgProfile } from 'react-icons/cg';
 import { BsFilePost } from 'react-icons/bs';
-import { FaHome,FaRegCopyright } from 'react-icons/fa';
+import { FaHome,FaRegCopyright,FaGithub } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
 import logo from "../assets/favicon.png";
 
@@ -77,14 +76,14 @@ const Footer = () => {
                 </div>
             </div>
            <div className='block w-3/4 m-auto mt-10'>
-                <div className='flex gap-4 justify-center md:justify-end'>
-                    <a href="https://github.com/VaibhavArora314/StyleShare" className="hover:scale-110 hover:shadow-[0_0_10px_2px_blue] transition-transform transition-shadow duration-300 ease">
-                        <img src={github} alt="github" className='pointer w-14 h-14' />
-                    </a>
-                    <Link to='/app' className="hover:scale-110 hover:shadow-[0_0_10px_2px_blue] transition-transform transition-shadow duration-300 ease flex items-center justify-center p-2 text-white rounded-full focus:outline-none">
-                        <FaHome size={35} />
-                    </Link>
-                </div>
+             <div className='flex gap-4 justify-center md:justify-end'>
+               <a href="https://github.com/VaibhavArora314/StyleShare" className="hover:scale-110 hover:shadow-[0_0_10px_2px_blue] transition-transform transition-shadow duration-300 ease-in-out flex items-center justify-center p-2 rounded-full">
+                 <FaGithub size={35} className="text-white" />
+               </a>
+            <Link to='/app' className="hover:scale-110 hover:shadow-[0_0_10px_2px_blue] transition-transform transition-shadow duration-300 ease-in-out flex items-center justify-center p-2 text-white rounded-full focus:outline-none">
+                 <FaHome size={35} />
+            </Link>
+              </div>
            </div>
            <div className='mt-10 text-gray-300 xl:flex justify-center text-md lg:text-xl xl:text-md'>
                 {t('footer.copy1')} <FaRegCopyright className="ml-2 mr-1 mt-1" /> {currentYear} {t('footer.copy2')}


### PR DESCRIPTION
# Pull Request

### Title
In footer's github and home icon not have same radius when we hover on that. 

### Description
Add same radius property add github icon from github now both looks similar hover effects.

### Related Issues
Fixes #333 

### Changes Made
Bug

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [x] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Screenshots (if applicable)

![image](https://github.com/VaibhavArora314/StyleShare/assets/126322584/ac59a536-f0bd-418e-b1ee-d275cfccfc98)

![image](https://github.com/VaibhavArora314/StyleShare/assets/126322584/971bc7d1-3e77-4f81-a3e5-d3d5dd31882b)
