### PR TITLE
Added margins when mobailmenu is opne

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import LanguageDropdown from "./LanguageDropdown";
 import { FaSun, FaMoon } from 'react-icons/fa';
 
- interface NavbarProps {
+interface NavbarProps {
   theme: 'light' | 'dark';
   toggleTheme: () => void;
 }
@@ -65,9 +65,9 @@ const Navbar: React.FC<NavbarProps> = ({ theme, toggleTheme })=> {
         >
           <span className="sr-only">Open Menu</span>
           <div className="flex flex-col gap-1">
-               <span className={`h-0.5 w-4 bg-white transform transition duration-200 ease-in ${isMenuOpen?"rotate-[45deg]":"rotate-0"}`}></span>
-               <span className={`h-0.5 w-4 ${isMenuOpen?"bg-transparent":"bg-white"} transition duration-200 ease-in ${isMenuOpen?"absolute":"relative"} `}></span>
-               <span className={`h-0.5 w-4 bg-white transform transition duration-200 ease-in ${isMenuOpen?"rotate-[-45deg]":"rotate-0"} ${isMenuOpen?"absolute":"relative"} `}></span>
+            <span className={`h-0.5 w-4 bg-white transform transition duration-200 ease-in ${isMenuOpen ? "rotate-[45deg]" : "rotate-0"}`}></span>
+            <span className={`h-0.5 w-4 ${isMenuOpen ? "bg-transparent" : "bg-white"} transition duration-200 ease-in ${isMenuOpen ? "absolute" : "relative"} `}></span>
+            <span className={`h-0.5 w-4 bg-white transform transition duration-200 ease-in ${isMenuOpen ? "rotate-[-45deg]" : "rotate-0"} ${isMenuOpen ? "absolute" : "relative"} `}></span>
           </div>
         </button>
         <div
@@ -94,7 +94,7 @@ const Navbar: React.FC<NavbarProps> = ({ theme, toggleTheme })=> {
               <div className="flex flex-col lg:flex-row lg:space-x-4">
                 <li className="mb-2 lg:mb-0">
                   <Link to="/app/signin" onClick={closeMenu}>
-                    <button className="relative inline-flex h-12 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50">
+                    <button className={`relative inline-flex h-12 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50 ${isMenuOpen ? "ml-3" : ""} ${isMenuOpen ? "mt-2" : ""}`}>
                       <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#E2CBFF_0%,#393BB2_50%,#E2CBFF_100%)]" />
                       <span className="inline-flex h-full w-full cursor-pointer items-center justify-center rounded-full bg-gradient-to-l from-[#c779e8] to-indigo-500 px-5 text-lg font-small text-white backdrop-blur-3xl">
                         {t("navbar.links.signin")}
@@ -104,7 +104,7 @@ const Navbar: React.FC<NavbarProps> = ({ theme, toggleTheme })=> {
                 </li>
                 <li>
                   <Link to="/app/signup" onClick={closeMenu}>
-                    <button className="relative inline-flex h-12 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50">
+                    <button className={`relative inline-flex h-12 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50 ${isMenuOpen ? "ml-3" : ""}`}>
                       <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#E2CBFF_0%,#393BB2_50%,#E2CBFF_100%)]" />
                       <span className="inline-flex h-full w-full cursor-pointer items-center justify-center rounded-full bg-gradient-to-l from-[#c779e8] to-indigo-500 px-5 text-lg font-small text-white backdrop-blur-3xl">
                         {t("navbar.links.signup")}
@@ -115,9 +115,9 @@ const Navbar: React.FC<NavbarProps> = ({ theme, toggleTheme })=> {
                 <li>
                   <button
                     onClick={toggleTheme}
-                    className="inline-flex mt-1 border-2 border-white items-center justify-center w-10 h-10 text-gray-100 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-gray-200"
+                    className={`inline-flex mt-1 border-2 border-white items-center justify-center w-10 h-10 text-gray-100 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-gray-200 ${isMenuOpen ? "ml-3" : ""} ${isMenuOpen ? "my-2" : ""} ${isMenuOpen ? "mt-2" : ""}`}
                   >
-                    {theme === 'light' ? <FaMoon className="w-4 h-4 " /> : <FaSun className="w-4 h-4" />}
+                    {theme === 'light' ? <FaMoon className="w-4 h-4" /> : <FaSun className="w-4 h-4" />}
                   </button>
                 </li>
 
@@ -152,11 +152,11 @@ const Navbar: React.FC<NavbarProps> = ({ theme, toggleTheme })=> {
                     {t("navbar.links.logout")}
                   </button>
                   <button
-                  onClick={toggleTheme}
-                  className="inline-flex mx-1  border-2 border-white items-center justify-center w-10 h-10 text-gray-100 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-gray-200"
-                >
-                  {theme === 'light' ? <FaMoon className="w-4 h-4 " /> : <FaSun className="w-4 h-4" />}
-                </button>
+                    onClick={toggleTheme}
+                    className={`inline-flex mx-1  border-2 border-white items-center justify-center w-10 h-10 text-gray-100 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-gray-200`}
+                  >
+                    {theme === 'light' ? <FaMoon className="w-4 h-4" /> : <FaSun className="w-4 h-4" />}
+                  </button>
                 </li>
               </>
             )}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import LanguageDropdown from "./LanguageDropdown";
 import { FaSun, FaMoon } from 'react-icons/fa';
 
-interface NavbarProps {
+ interface NavbarProps {
   theme: 'light' | 'dark';
   toggleTheme: () => void;
 }
@@ -65,9 +65,9 @@ const Navbar: React.FC<NavbarProps> = ({ theme, toggleTheme })=> {
         >
           <span className="sr-only">Open Menu</span>
           <div className="flex flex-col gap-1">
-            <span className={`h-0.5 w-4 bg-white transform transition duration-200 ease-in ${isMenuOpen ? "rotate-[45deg]" : "rotate-0"}`}></span>
-            <span className={`h-0.5 w-4 ${isMenuOpen ? "bg-transparent" : "bg-white"} transition duration-200 ease-in ${isMenuOpen ? "absolute" : "relative"} `}></span>
-            <span className={`h-0.5 w-4 bg-white transform transition duration-200 ease-in ${isMenuOpen ? "rotate-[-45deg]" : "rotate-0"} ${isMenuOpen ? "absolute" : "relative"} `}></span>
+               <span className={`h-0.5 w-4 bg-white transform transition duration-200 ease-in ${isMenuOpen?"rotate-[45deg]":"rotate-0"}`}></span>
+               <span className={`h-0.5 w-4 ${isMenuOpen?"bg-transparent":"bg-white"} transition duration-200 ease-in ${isMenuOpen?"absolute":"relative"} `}></span>
+               <span className={`h-0.5 w-4 bg-white transform transition duration-200 ease-in ${isMenuOpen?"rotate-[-45deg]":"rotate-0"} ${isMenuOpen?"absolute":"relative"} `}></span>
           </div>
         </button>
         <div
@@ -104,7 +104,7 @@ const Navbar: React.FC<NavbarProps> = ({ theme, toggleTheme })=> {
                 </li>
                 <li>
                   <Link to="/app/signup" onClick={closeMenu}>
-                    <button className={`relative inline-flex h-12 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50 ${isMenuOpen ? "ml-3" : ""}`}>
+                   <button className={`relative inline-flex h-12 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50 ${isMenuOpen ? "ml-3" : ""}`}>
                       <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#E2CBFF_0%,#393BB2_50%,#E2CBFF_100%)]" />
                       <span className="inline-flex h-full w-full cursor-pointer items-center justify-center rounded-full bg-gradient-to-l from-[#c779e8] to-indigo-500 px-5 text-lg font-small text-white backdrop-blur-3xl">
                         {t("navbar.links.signup")}
@@ -115,9 +115,9 @@ const Navbar: React.FC<NavbarProps> = ({ theme, toggleTheme })=> {
                 <li>
                   <button
                     onClick={toggleTheme}
-                    className={`inline-flex mt-1 border-2 border-white items-center justify-center w-10 h-10 text-gray-100 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-gray-200 ${isMenuOpen ? "ml-3" : ""} ${isMenuOpen ? "my-2" : ""} ${isMenuOpen ? "mt-2" : ""}`}
+                   className={`inline-flex mt-1 border-2 border-white items-center justify-center w-10 h-10 text-gray-100 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-gray-200 ${isMenuOpen ? "ml-3" : ""} ${isMenuOpen ? "my-2" : ""} ${isMenuOpen ? "mt-2" : ""}`}
                   >
-                    {theme === 'light' ? <FaMoon className="w-4 h-4" /> : <FaSun className="w-4 h-4" />}
+                    {theme === 'light' ? <FaMoon className="w-4 h-4 " /> : <FaSun className="w-4 h-4" />}
                   </button>
                 </li>
 
@@ -152,11 +152,11 @@ const Navbar: React.FC<NavbarProps> = ({ theme, toggleTheme })=> {
                     {t("navbar.links.logout")}
                   </button>
                   <button
-                    onClick={toggleTheme}
-                    className={`inline-flex mx-1  border-2 border-white items-center justify-center w-10 h-10 text-gray-100 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-gray-200`}
-                  >
-                    {theme === 'light' ? <FaMoon className="w-4 h-4" /> : <FaSun className="w-4 h-4" />}
-                  </button>
+                  onClick={toggleTheme}
+                  className="inline-flex mx-1  border-2 border-white items-center justify-center w-10 h-10 text-gray-100 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-gray-200"
+                >
+                  {theme === 'light' ? <FaMoon className="w-4 h-4 " /> : <FaSun className="w-4 h-4" />}
+                </button>
                 </li>
               </>
             )}


### PR DESCRIPTION
# Pull Request

### Title
In mobile screen navbar section sing in/sing up and mode change button not have proper margin

### Description
Added margins properly when mobile menu is open

### Related Issues
Fixes #353 

### Changes Made
BUG

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [x] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Screenshots (if applicable)
