### PR TITLE
Fix image to stop wasting of space

### DIFF
--- a/frontend/src/pages/Policy.tsx
+++ b/frontend/src/pages/Policy.tsx
@@ -23,7 +23,7 @@ function Policy() {
   }, [location]);
 
   return (
-    <div className="w-full text-[#000435] bg-white dark:text-white dark:bg-[#000435] py-16 px-4 ">
+    <div className="w-full text-[#000435] bg-white dark:text-white dark:bg-[#000435] py-16 px-4 lg:px-16 mx-auto">
       <div className="flex flex-col items-start">
         <div className="flex items-center mb-8 w-full">
           <div className="flex flex-col">

--- a/frontend/src/pages/Policy.tsx
+++ b/frontend/src/pages/Policy.tsx
@@ -26,9 +26,11 @@ function Policy() {
     <div className="w-full text-[#000435] bg-white dark:text-white dark:bg-[#000435] py-16 px-4 ">
       <div className="flex flex-col items-start">
         <div className="flex items-center mb-8 w-full">
-          <img src={privacy} alt="Privacy" className="rounded-lg w-32 h-32 mr-8" />
           <div className="flex flex-col">
-            <h1 id="privacy-policy" className="text-3xl font-bold mb-4 scroll-margin-top">Privacy Policy</h1>
+          <div className="flex items-center mb-4">
+               <h1 id="privacy-policy" className="text-3xl font-bold">Privacy Policy</h1>
+              <img src={privacy} alt="Privacy" className="rounded-full mr-4 h-12 w-12 ml-2 hover:scale-110 transition-transform duration-300" />
+          </div>
             <section>
               <p>Your privacy is important to us. This privacy policy explains how we collect, use, and protect your personal information when you use our website.</p>
               <h3 className="text-xl font-semibold mt-4">1. Information We Collect</h3>
@@ -60,9 +62,11 @@ function Policy() {
         </div>
 
         <div className="flex items-center mb-8 w-full">
-          <img src={terms} alt="Terms" className="rounded-lg w-32 h-32 mr-8" />
           <div className="flex flex-col">
+          <div className="flex items-center mb-4">
             <h1 id="terms-and-conditions" className="text-3xl font-bold mb-4 scroll-margin-top">Terms and Conditions</h1>
+            <img src={terms} alt="Terms" className="rounded-full mr-4  h-12 w-12 ml-2 mb-3 hover:scale-110 transition-transform duration-300" />
+          </div>
             <section>
               <p>Please read these terms and conditions carefully before using our website.</p>
               <h3 className="text-xl font-semibold mt-4">1. Acceptance of Terms</h3>
@@ -94,9 +98,11 @@ function Policy() {
         </div>
 
         <div className="flex items-center mb-8 w-full">
-          <img src={cookie} alt="Cookie" className="rounded-lg w-32 h-32 mr-8" />
           <div className="flex flex-col">
+          <div className="flex items-center mb-4">
             <h1 id="cookie-policy" className="text-3xl font-bold mb-4 scroll-margin-top">Cookie Policy</h1>
+            <img src={cookie} alt="Cookie" className="rounded-full mr-4  h-12 w-12 ml-2 mb-3 hover:scale-110 transition-transform duration-300" />
+          </div>
             <section>
               <p>This cookie policy explains how we use cookies and similar technologies on our website.</p>
               <h3 className="text-xl font-semibold mt-4">1. What Are Cookies?</h3>


### PR DESCRIPTION
# Pull Request

### Title
In Privacy Policy, Terms and Conditions, Cookie Policy image takes lots of space in left side. 

### Description

Fix image like 

Privacy Policy (image as a symbol)

Added hover scale on that image for user feel.

By this save space wasting in left side and get better view in small screen.

### Related Issues

Fixes #383 

### Changes Made

Change position of image and style.

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [x] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Screenshots (if applicable)
![WhatsApp Image 2024-07-11 at 17 54 47_b4199fbe](https://github.com/VaibhavArora314/StyleShare/assets/126322584/373a78dd-0d2d-45b8-a06e-04ffc48d81f6)

![WhatsApp Image 2024-07-11 at 17 55 00_82387d55](https://github.com/VaibhavArora314/StyleShare/assets/126322584/619d30b1-8a09-493e-b0a1-8421633e7bcf)

![WhatsApp Image 2024-07-11 at 17 55 11_c023a685](https://github.com/VaibhavArora314/StyleShare/assets/126322584/bf7fcd33-ad3d-4ed8-8819-79383ce55f53)


**In small size screen looks great now**

![WhatsApp Image 2024-07-11 at 17 55 34_06b3b439](https://github.com/VaibhavArora314/StyleShare/assets/126322584/bf9ee465-c385-44bb-b6ba-7f94fed04f97)




