### PR TITLE
Added Github link in Contributor

### DIFF
--- a/frontend/src/pages/Contributors.tsx
+++ b/frontend/src/pages/Contributors.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import bgHero from "../assets/bgHero.png";
+import { FaGithub } from 'react-icons/fa';
 
 interface Contributor {
   id: number;
@@ -41,23 +42,26 @@ const Contributors: React.FC = () => {
               key={contributor.id}
               className="w-full md:w-1/3 lg:w-1/4 flex flex-col items-center bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg shadow-md p-4 transition-transform transform hover:scale-105 hover:shadow-xl"
             >
-              <a
-                href={contributor.html_url}
-                className="block"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
                 <img
                   src={contributor.avatar_url}
                   alt={contributor.login}
                   className="w-24 h-24 rounded-full object-cover mb-4"
                 />
-              </a>
               <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
                 {contributor.login}
               </h2>
               <p className="text-gray-700 dark:text-gray-400">
                 Contributions: {contributor.contributions}
+              </p>
+              <p className="text-gray-700 dark:text-gray-400 flex items-center">
+                <a
+                   href={contributor.html_url}
+                   className="flex items-center"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                >
+                    <FaGithub className="mr-1" /> GitHub Profile
+                </a>
               </p>
             </div>
           ))}

--- a/frontend/src/pages/Contributors.tsx
+++ b/frontend/src/pages/Contributors.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import bgHero from "../assets/bgHero.png";
-import { FaGithub } from 'react-icons/fa';
 
 interface Contributor {
   id: number;
@@ -55,9 +54,6 @@ const Contributors: React.FC = () => {
               </h2>
               <p className="text-gray-700 dark:text-gray-400">
                 Contributions: {contributor.contributions}
-              </p>
-              <p className="text-gray-700 dark:text-gray-400 flex items-center">
-                <FaGithub className="mr-1" /> GitHub Profile
               </p>
             </a>
           ))}

--- a/frontend/src/pages/Contributors.tsx
+++ b/frontend/src/pages/Contributors.tsx
@@ -38,15 +38,18 @@ const Contributors: React.FC = () => {
         <h1 className="text-center text-3xl font-semibold mb-8">🤝 Contributors</h1>
         <div className="flex flex-wrap justify-center gap-8">
           {contributors.map((contributor) => (
-            <div
+            <a
               key={contributor.id}
+              href={contributor.html_url}
               className="w-full md:w-1/3 lg:w-1/4 flex flex-col items-center bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg shadow-md p-4 transition-transform transform hover:scale-105 hover:shadow-xl"
+              target="_blank"
+              rel="noopener noreferrer"
             >
-                <img
-                  src={contributor.avatar_url}
-                  alt={contributor.login}
-                  className="w-24 h-24 rounded-full object-cover mb-4"
-                />
+              <img
+                src={contributor.avatar_url}
+                alt={contributor.login}
+                className="w-24 h-24 rounded-full object-cover mb-4"
+              />
               <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
                 {contributor.login}
               </h2>
@@ -54,16 +57,9 @@ const Contributors: React.FC = () => {
                 Contributions: {contributor.contributions}
               </p>
               <p className="text-gray-700 dark:text-gray-400 flex items-center">
-                <a
-                   href={contributor.html_url}
-                   className="flex items-center"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                >
-                    <FaGithub className="mr-1" /> GitHub Profile
-                </a>
+                <FaGithub className="mr-1" /> GitHub Profile
               </p>
-            </div>
+            </a>
           ))}
         </div>
       </div>
@@ -72,4 +68,3 @@ const Contributors: React.FC = () => {
 };
 
 export default Contributors;
-


### PR DESCRIPTION
# Pull Request

### Title

Contibutor github profile link is on image so user can't understand that make github link seperate.

### Description

Add one p tag in that add link and remove link from image.

### Related Issues

Fixes #418

### Changes Made

Add one p tag in that add link and remove link from image.

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [x] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/e8250dcf-8f39-45d3-8dc2-e00209d9a9a3)
