### PR TITLE
Bug: Fixed the page not found text in light/dark mode successfully issue 429

### DIFF
--- a/admin/src/pages/PageNotFound.tsx
+++ b/admin/src/pages/PageNotFound.tsx
@@ -9,7 +9,7 @@ const PageNotFound = () => {
         <img src={notfound} alt='Page Not Found' className='w-[400px]' /> 
         <p className='text-center mb-20'>
             <span className='text-red-600 font-bold text-6xl'>404</span><br />
-            <span className='text-gray-200 ite text-3xl font-semibold'>Page Not Found</span>
+            <span className='text-gray-800 text-3xl font-bold dark:text-gray-200'>Page Not Found</span>
         </p>    
     </div>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,7 +32,6 @@ import CodeEditor from "./pages/CodeEditor";
 import Contributors from "./pages/Contributors";
 import userBlock from "./hooks/userBlock";
 import Blocked from "./pages/Blocked";
-
 // import axios from "axios";
 // axios.defaults.baseURL = "http://localhost:3001/";
 

--- a/frontend/src/pages/PageNotFound.tsx
+++ b/frontend/src/pages/PageNotFound.tsx
@@ -11,7 +11,7 @@ const PageNotFound = () => {
         <img src={notfound} alt='Page Not Found' className='w-[400px]' /> 
         <p className='text-center mb-20'>
             <span className='text-red-600 font-bold text-6xl'>404</span><br />
-            <span className='text-gray-200 ite text-3xl font-semibold'>{t('notfound')}</span>
+            <span className='text-gray-800 text-3xl font-bold dark:text-gray-200'>{t('notfound')}</span>
         </p>    
     </div>
   )


### PR DESCRIPTION
# Pull Request Resolves [#429 ]

### Title: Fixed the page not found text in light/dark mode successfully.

### Description

1. In frontend as well as in admin the Page not found text is visible in light/dark mode, by changing the css for dark theme.

### Related Issues
Fixes #429 

### Changes Made
Bug fixes: Fixed the page not found text in light/dark mode.

### Screenshots

![image](https://github.com/user-attachments/assets/b58aac91-741f-4976-8cde-b9787c874ba1)

![image](https://github.com/user-attachments/assets/ca738c53-3fb7-4b62-92c8-fd090a995f86)

I certify that I have carried out the relevant code of conduct and provided the requisite screenshot for validation by submitting this pull request.

Thank You for this contribution.