### PR TITLE
Fixes the Like button in the postcard

### DIFF
--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -44,7 +44,9 @@ const PostCard = ({ post, onDelete, currentUser }: Props) => {
     setIsFavorite(favoriteStatus === "true");
   }, [post.id]);
 
-  const handleAddToFavorite = async () => {
+  const handleAddToFavorite = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
     try {
       const token = localStorage.getItem("token");
       if (!token) {
@@ -79,7 +81,9 @@ const PostCard = ({ post, onDelete, currentUser }: Props) => {
     }
   };
 
-  const handleRemoveFromFavorite = async () => {
+  const handleRemoveFromFavorite = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
     try {
       const token = localStorage.getItem("token");
       if (!token) {


### PR DESCRIPTION
# Pull Request

### Title
<!-- Provide a clear and concise title for the pull request -->
Fixes the Like button in the postcard

### Description
<!-- Brief summary of the changes made and the purpose of the PR -->
We do not want to be redirected to the read more page when we are liking the post card, and vice versa. Instead, we only want to like the post itself.

### Related Issues
<!-- Mention any related issue numbers (e.g., "Fixes #123") -->
closes #503 

### Changes Made
<!-- List of changes made in the PR (e.g., new features, bug fixes, improvements) -->
The react mouse event was only added after the file (PostCard.tsx) was modified.

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [x] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Screenshots (if applicable)
<!-- Add any relevant screenshots to illustrate the changes -->
[Screencast from 25-07-24 02:47:24 PM IST.webm](https://github.com/user-attachments/assets/cdceab8b-78f3-40d0-ad60-a106d1f26c7e)


### Additional Notes
<!-- Any additional information that might be helpful for the reviewer -->

Footer
