### PR TITLE
Bug: Fixed margin bottom in all tables in admin panel successfully issue 498

### DIFF
--- a/admin/src/pages/Comments.tsx
+++ b/admin/src/pages/Comments.tsx
@@ -49,8 +49,8 @@ const Comments = () => {
 
   return (
     <div>
-      <div className="lg:ml-80">
-        <div className="mx-5 mb-5">
+      <div className="flex-1 flex flex-col lg:ml-80">
+      <div className="mx-5 mb-5">
         <span className="flex  items-center  text-xl font-bold decoration-sky-500 decoration-dotted underline">
           <div className='inline-block p-2 text-white bg-[#000435] rounded-lg mr-2'>
             <FaComments size={23} />

--- a/admin/src/pages/Posts.tsx
+++ b/admin/src/pages/Posts.tsx
@@ -50,11 +50,11 @@ const Posts = () => {
 
   return (
     <div>
-      <div className="lg:ml-80">
-        <div className="mx-5 mb-5">
-        <span className="flex  items-center  text-xl font-bold decoration-sky-500 decoration-dotted underline">
-          <div className='inline-block p-2 text-white bg-[#000435] rounded-lg mr-2'>
-            <BsFillPostcardFill size={23} />
+      <div className="flex-1 flex flex-col lg:ml-80">
+      <div className="mx-5 mb-5">
+      <span className="flex  items-center  text-xl font-bold decoration-sky-500 decoration-dotted underline">
+      <div className='inline-block p-2 text-white bg-[#000435] rounded-lg mr-2'>
+      <BsFillPostcardFill size={23} />
           </div>
           All Posts
         </span>
@@ -69,9 +69,9 @@ const Posts = () => {
         />
       </div>
       :
-        <div className="mx-5 lg:mr-11 overflow-x-auto shadow-md rounded-xl mb-5">
-          <table className="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400">
-            <thead className="text-xs text-white uppercase bg-sky-500">
+      <div className="mx-5 lg:mr-11 overflow-x-auto shadow-md rounded-xl mb-5">
+      <table className="w-full rtl:text-right text-gray-500 dark:text-gray-400">
+        <thead className="text-xs md:text-sm text-white uppercase bg-sky-500 text-center">
               <tr>
                 <th scope="col" className="px-8 py-3">Title</th>
                 <th scope="col" className="px-8 py-3">Author</th>
@@ -106,7 +106,7 @@ const Posts = () => {
               ))}
             </tbody>
           </table>
-        </div>
+          </div>
       }
       </div>
     </div>


### PR DESCRIPTION
# Pull Request Resolves [ #498 ]

### Title: Fixed margin bottom in all tables in admin panel successfully.

### Description

1. In admin, I added the flex and margin bottom to give the margin bottom to the tables.
2. The design is responsive.

### Related Issues
Fixes #498 

### Changes Made
Bug fix: Fixed margin bottom in all tables in admin panel.

### Screenshots

![image](https://github.com/user-attachments/assets/ade73c17-e315-4555-a660-75e877c610d8)

![image](https://github.com/user-attachments/assets/20a29c61-6c5f-4abc-8d0b-b2bc2f913c71)

I certify that I have carried out the relevant code of conduct and provided the requisite screenshot for validation by submitting this pull request.

Thank You for this contribution.