### PR TITLE
✔️Added MIT License in Footer

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -92,7 +92,7 @@ const Footer = () => {
                                 </Link>
                             </li>
                             <li className='py-1 cursor-pointer'>
-                                <Link to='https://github.com/VaibhavArora314/StyleShare?tab=MIT-1-ov-file#readme' className='flex items-center gap-2 link-hover'>
+                                <Link to='/app/policy#licensing' className='flex items-center gap-2 link-hover'>
                                 <FaFileContract className="w-4 h-4 mr-0.5" />
                                     Licensing
                                 </Link>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { loggedInState } from '../store/atoms/auth';
 import { CgProfile } from 'react-icons/cg';
 import { BsFilePost } from 'react-icons/bs';
-import { FaHome, FaGithub, FaEnvelope, FaInfoCircle, FaTools, FaLock, FaFileAlt, FaCookieBite } from 'react-icons/fa';
+import { FaHome, FaGithub, FaEnvelope, FaInfoCircle, FaTools, FaLock, FaFileAlt, FaCookieBite, FaFileContract} from 'react-icons/fa';
 import logo from "../assets/favicon.png";
 import { FaRegHandshake } from "react-icons/fa6";
 import "../styles/Footer.css"; 
@@ -89,6 +89,12 @@ const Footer = () => {
                                 <Link to='/app/policy#terms-and-conditions' className='flex items-center gap-2 link-hover'>
                                     <FaFileAlt />
                                     Terms and Conditions
+                                </Link>
+                            </li>
+                            <li className='py-1 cursor-pointer'>
+                                <Link to='https://github.com/VaibhavArora314/StyleShare?tab=MIT-1-ov-file#readme' className='flex items-center gap-2 link-hover'>
+                                <FaFileContract className="w-4 h-4 mr-0.5" />
+                                    Licensing
                                 </Link>
                             </li>
                             <li className='py-1 cursor-pointer'>

--- a/frontend/src/pages/Policy.tsx
+++ b/frontend/src/pages/Policy.tsx
@@ -164,6 +164,22 @@ function Policy() {
             </div>
           </div>
         </div>
+
+        <div className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-md transition-transform duration-300 hover:shadow-lg transform hover:scale-105">
+          <div className="flex flex-col md:flex-row items-start space-y-4 md:space-y-0 md:space-x-8 mb-8">
+            <img src={terms} alt="MITLicense" className="rounded-lg w-32 h-32" />
+            <div>
+              <h1 id="licensing" className="text-4xl font-bold mb-4 scroll-margin-top">Licensing</h1>
+              <section className="leading-relaxed space-y-4">
+              <h3 className="text-2xl font-semibold mt-4">MIT License</h3>
+                <p>Our project is distributed under the MIT License, a permissive free software license that allows you to reuse, modify, and distribute the software with minimal restrictions, ensuring flexibility and freedom in your development endeavors.</p>
+                
+                <p>For more detailed information about the MIT License, please click on the link provided to the license.</p>
+                <a href="https://github.com/VaibhavArora314/StyleShare?tab=MIT-1-ov-file#readme" className="text-blue-500 font-bold underline hover:text-blue-700">View MIT License</a>
+              </section>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Hey @VaibhavArora314 , @akbatra567 and @Ultimateutkarsh11 
issue closes #538 

I have added the MIT License navigating link in the footer.

Please take a look - 
![image](https://github.com/user-attachments/assets/5f667f3a-931c-4f9b-b303-2d9934629678)


https://github.com/user-attachments/assets/cb19b20e-50f3-427c-a8ea-e1cee0512724



### Changes Made
<!-- List of changes made in the PR (e.g., new features, bug fixes, improvements) -->

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [ ] I have tested the changes locally
- [ ] Documentation has been updated (if necessary)
- [ ] Changes are backward-compatible

### Screenshots (if applicable)
<!-- Add any relevant screenshots to illustrate the changes -->

### Additional Notes
<!-- Any additional information that might be helpful for the reviewer -->

Footer
