### PR TITLE
Added Enter to search functionality in posts page

### DIFF
--- a/frontend/src/pages/Posts.tsx
+++ b/frontend/src/pages/Posts.tsx
@@ -77,6 +77,7 @@ const Posts = () => {
 
   const handleSearch = () => {
     fetchPosts(page, 12, searchQuery, filterTags);
+    // console.log(searchQuery)
   };
 
   if (loading) {
@@ -165,7 +166,12 @@ const Posts = () => {
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="🔍 Search anything"
               className="p-2 w-full max-w-xs rounded-md text-[#000435] bg-white dark:text-white dark:bg-[#000435] border border-sky-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
+              onKeyDown={(event)=>{
+                if(event.key == "Enter"){
+                  handleSearch()
+                }
+              }}
+            />
             <button
               onClick={handleSearch}
               className="bg-blue-500 text-white px-4 py-2 rounded ml-2 hover:bg-blue-600 transition-colors duration-200"

--- a/frontend/src/pages/Posts.tsx
+++ b/frontend/src/pages/Posts.tsx
@@ -77,7 +77,6 @@ const Posts = () => {
 
   const handleSearch = () => {
     fetchPosts(page, 12, searchQuery, filterTags);
-    // console.log(searchQuery)
   };
 
   if (loading) {


### PR DESCRIPTION
# Pull Request

### Title
<!-- Provide a clear and concise title for the pull request -->
Added press Enter to search functionality in posts page

### Description
<!-- Brief summary of the changes made and the purpose of the PR -->
Previously, in posts section, while searching for a post we have to click on "search" button to search for a specific keyword post.
I added functionality so that, we can directly type our keyword and hit "ENTER" to search, thus improving user experience.

### Related Issues
<!-- Mention any related issue numbers (e.g., "Fixes #123") -->
Fixes #549 

### Changes Made
<!-- List of changes made in the PR (e.g., new features, bug fixes, improvements) -->
Added a key event in searchbox which is triggered when ENTER key is pressed, calling the "handleSubmit" function which then takes care of fetching relevant posts.


### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [X] I have tested the changes locally
- [X] Documentation has been updated (if necessary)
- [X] Changes are backward-compatible

### Screenshots (if applicable)
<!-- Add any relevant screenshots to illustrate the changes -->

https://github.com/user-attachments/assets/b79db1b5-bf74-4520-af0f-2298eded0829


### Additional Notes
<!-- Any additional information that might be helpful for the reviewer -->

Footer
Thanks for assigning me this issue.
