### PR TITLE
Bug: Fixed fetch favorite post status code successfully issue 570

### DIFF
--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -42,6 +42,9 @@ const PostCard = ({ post, onDelete, currentUser }: Props) => {
   useEffect(() => {
     const fetchFavoriteStatus = async () => {
       try {
+        if (!currentUser) {
+          return;
+        }
         const token = localStorage.getItem("token");
         if (!token) {
           return;
@@ -56,9 +59,10 @@ const PostCard = ({ post, onDelete, currentUser }: Props) => {
         toast.error("Failed to fetch favorite status");
       }
     };
-
+  
     fetchFavoriteStatus();
-  }, [post.id]);
+  }, [post.id, currentUser]);
+  
 
   const handleAddToFavorite = async (event: React.MouseEvent) => {
     event.stopPropagation();


### PR DESCRIPTION
# Pull Request Resolves [ #570 ]

### Title: Fixed fetch favorite post status code successfully.

### Description

1. In frontend, I am calling the status code for favorite when user is login only.
2. Because of this the api is never hit when other users hit the page.

### Related Issues
Fixes #570 

### Changes Made
Bug fixe: Fixed fetch favorite post status code.

### Screenshots 

![image](https://github.com/user-attachments/assets/94f6f26f-a812-4948-8197-494e458a6069)

I certify that I have carried out the relevant code of conduct and provided the requisite screenshot for validation by submitting this pull request.

Thank You for this contribution.